### PR TITLE
FIX: only build and deploy on main branch

### DIFF
--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -1,5 +1,8 @@
 name: Build and Deploy
-on: [push]
+on:
+  push:
+    branches:
+      - main
 permissions: 
   contents: write
 jobs:


### PR DESCRIPTION
Currently a push to any branch would build. Probably not a big issue because we don't have multiple branches within the main repo.