### PR TITLE
remove link to core api docs

### DIFF
--- a/known-packages.toml
+++ b/known-packages.toml
@@ -310,11 +310,6 @@ badges = [
 
 [documentation]
 
-[documentation.python-yaq-fyi]
-badges = [
-  "<a href='https://github.com/yaq-project/python-yaq-fyi'><img src='https://img.shields.io/github/checks-status/yaq-project/python-yaq-fyi/main'></a>",
-]
-
 [documentation.yeps]
 badges = [
   "<a href='https://github.com/yaq-project/yeps'><img src='https://img.shields.io/github/checks-status/yaq-project/yeps/main'></a>",

--- a/posts/installing-yaq.md
+++ b/posts/installing-yaq.md
@@ -44,7 +44,6 @@ install yaqc
 ------------
 
 yaqc is a general purpose Python client which will afford you basic communication with any yaq daemon.
-Full yaqc documentation is avaliable at [python.yaq.fyi/yaqc](https://python.yaq.fyi/yaqc).
 
     > conda install yaqc
 

--- a/posts/scipy-2020-recap.md
+++ b/posts/scipy-2020-recap.md
@@ -7,10 +7,6 @@ authors: Kyle Sunden
 
 [TOC]
 
-## Virtual 'Poster'
-
-[Here](https://python.yaq.fyi/scipy-2020/) is a link to our SciPy 2020 virtual 'poster'.
-
 ## Hardware Birds-Of-a-Feather session
 
 Blaise Thompson and Kyle Sunden (the lead developers of yaq) hosted a BOF at Scipy 2020, the [recording](https://www.youtube.com/watch?v=6HxVbK14EDI) is available on youtube.

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,7 +27,6 @@ Subdomains:
 <p>
 <a href="https://yeps.yaq.fyi">yaq enhancement proposals</a> </br>
 <a href="https://control.yaq.fyi">yaqd-control</a> </br>
-<a href="https://yaqd-core-python.yaq.fyi">yaqd-core-python</a> </br>
 <a href="https://traits.yaq.fyi">yaq-traits</a> </br>
 </p>
 


### PR DESCRIPTION
As noticed by @kadykov in #66, this link goes nowhere. We don't serve API docs for yaqd-core-python anymore. Our toolchain broke.

Should we serve such docs? Maybe... but in the meantime best to remove the broken link.